### PR TITLE
Retouche de l'énoncé de l'exercice 5 Attribut

### DIFF
--- a/Ex05_MVC_Attribut/Ex05 MVC_Attribut.html
+++ b/Ex05_MVC_Attribut/Ex05 MVC_Attribut.html
@@ -39,9 +39,10 @@
 			<li>L'adresse e-mail doit être obligatoire et suivre le format d'une adresse e-mail valide.</li>
 			<li>L'adresse de livraison doit être obligatoire et avoir une longueur maximale de 200 caractères.</li>
 			<li>La date de commande doit être obligatoire et représenter une date valide.</li>
-			<li>Le montant total de la commande doit être obligatoire et supérieur à zéro.</li>
+			<li>Le montant total de la commande doit être obligatoire et supérieur ou égal à zéro.</li>
 			<li>Le statut de la commande doit être obligatoire et correspondre à une des valeurs prédéfinies.</li>
 			<li>Chaque commande doit contenir au moins un détail de commande avec une quantité valide.</li>
+			<li>Un détail de commande ne peut pas être modifié si la commande est en préparation, sinon, il peut être modifié via l'édition de commande.</li>
 		</ul> 
 		
 		 <p>
@@ -51,6 +52,10 @@
 		<ul>
 			<li>Afin de séparer les couches, implémentez un viewModel <strong> OrderViewModel</strong>.</li>
 		</ul>
+
+		<p>
+			<i>Note : Vous ne pouvez pas utiliser le fait que le montant total de la commande est égal à 0 pour valider ou nom la liste de détails de la commande. </i>
+		</p>
 		
 </body>
 


### PR DESCRIPTION
Modifications apportées à l'énoncé de l'exercice 5 MVC_Attribut : 
- Retouche de la validation du montant.
- Ajout du prérequis de pouvoir éditer un détail de commande.
- Ajout d'une note pour empêcher d'utiliser le montant total à 0 comme élément de validation des détails.